### PR TITLE
Avoid API errors with empty results and nolog

### DIFF
--- a/libcif/lib/CIF/Client.pm
+++ b/libcif/lib/CIF/Client.pm
@@ -184,7 +184,11 @@ sub decode_results {
     debug('decoding...') if($::debug);
     ## TODO: finish this so feeds are inline with reg queries
     ## TODO: try to base64 decode and decompress first in try { } catch;
-    foreach my $feed (@{$ret->get_data()}){
+    my $feed_data = $ret->get_data();
+    if(!defined($feed_data)){
+        $feed_data = [ ];
+    }
+    foreach my $feed (@{$feed_data}){
         my @array;
         my $err;
         my $test;


### PR DESCRIPTION
If a query is made via the API for a subject with no results and nolog
is passed there will be no data returned. This was causing a 'Can't use
an undefined value as an ARRAY reference' error and apache would return
500.

This change adds a check to ensure data was returned before attempting
to treat it as an array.

Tested: API and command line calls for known subjects ('google.com') and
unknown subjects ('echo1234') with nolog on and nolog off. Confirmed no
exceptions.
