### PR TITLE
Fix error for hostname starting with IPv4 address

### DIFF
--- a/libcif/lib/CIF/Client/Query/Ipv4.pm
+++ b/libcif/lib/CIF/Client/Query/Ipv4.pm
@@ -12,7 +12,7 @@ sub process {
     my $class   = shift;
     my $args    = shift;
 
-    return unless($args->{'query'} =~ /^$RE{'net'}{'IPv4'}/);
+    return unless($args->{'query'} =~ /^$RE{'net'}{'IPv4'}$/ || $args->{'query'} =~ /^$RE{'net'}{'CIDR'}{'IPv4'}$/);
     $args->{'query'} = normalize_address($args->{'query'});
   
     my $pt = $args->{'pt'};


### PR DESCRIPTION
Hostname queries for non-IPv4 subjects which match an IP address were
causing 500 errors from the CIF API. This change updates the regex test
to be more specific in determining if the query should be treated as an
IPv4 address or a hostname.

Example hostname which would cause an error: 1.2.3.4.mydomain.com

Tested: Perform queries of:
- hostname prefaced with an IPv4 address
- CIDR address
- IPv4 address
  Confirmed CIDR and IPv4 addresses were matched by updated regex.
