### PR TITLE
Direct automake to use USTAR format for tar when creating dist bundles

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ([2.64])
 AC_INIT(cif-v1, m4_esyscmd_s([git describe --tags]), [ci-framework@googlegroups.com])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([1.9 tar-ustar])
 
 # setup
 


### PR DESCRIPTION
When creating dist bundles for pre-release tags some path lengths may exceed the 99 character limit imposed by tar v7.  This change directs autoconf to generate a dist target that uses the USTAR format.
