### PR TITLE
AJAX: Support Chrome's preflight OPTIONS request to look for CORS headers

### DIFF
--- a/cif-router/lib/CIF/Router/HTTP/Json.pm
+++ b/cif-router/lib/CIF/Router/HTTP/Json.pm
@@ -169,6 +169,10 @@ sub handler {
                 data    => $ret->get_data(),
             });
         }
+        if(/^OPTIONS$/){
+            # AJAX: Support Chrome's preflight OPTIONS request to look for CORS headers
+            return '';
+        }
     }
     return Apache2::Const::FORBIDDEN();
     


### PR DESCRIPTION
Hi

I've added support to OPTIONS request in JSON module. It is required by Chrome which is doing preflight request before actual AJAX call to check CORS headers. It happens in a situation when a web app using CIF API and the CIF backend itself are located on different hosts.

It also makes sense to configure Apache to add CORS headers to each
response:

SetEnvIf Origin "^https?://(your-web-app)$" origin_is=$0
Header always set Access-Control-Allow-Origin %{origin_is}e env=origin_is
Header always set Access-Control-Allow-Headers "x-requested-with"
